### PR TITLE
Switch from phantomjs to headless chrome

### DIFF
--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -8,8 +8,9 @@ a local clone to work with. If you need help with things like forking, cloning,
 and git in general, we recommend Udacity's [How to Use Git and
 GitHub](https://www.udacity.com/course/how-to-use-git-and-github--ud775) course.
 
-You will also need [PhantomJS](http://phantomjs.org/) installed. You can
-download it from that webpage, or on a Mac simply run `brew install phantomjs`.
+You will also need
+[ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/) installed.
+On a Mac simply run `brew install chromedriver`.
 
 Once you have a copy of this project on your machine, you should run
 `bin/setup`. At this point, it's a good idea to

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :test do
   gem 'database_cleaner'
   gem 'db-query-matchers'
   gem 'launchy'
-  gem 'poltergeist'
+  gem 'capybara-selenium'
   gem 'rails-controller-testing'
   gem 'rspec-collection_matchers'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,11 @@ GEM
     capybara-screenshot (1.0.18)
       capybara (>= 1.0, < 3)
       launchy
-    cliver (0.3.2)
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -217,10 +221,6 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     pg (0.21.0)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -304,6 +304,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
@@ -316,6 +317,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     shellany (0.0.1)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
@@ -382,6 +386,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
+  capybara-selenium
   coffee-rails (~> 4.2)
   database_cleaner
   db-query-matchers
@@ -403,7 +408,6 @@ DEPENDENCIES
   listen
   mail_interceptor
   pg (~> 0.18)
-  poltergeist
   pry
   puma (~> 3.0)
   rails (~> 5.2.0)

--- a/app/views/dashboards/_station_map.html.erb
+++ b/app/views/dashboards/_station_map.html.erb
@@ -1,6 +1,8 @@
-<script async defer
-src="https://maps.googleapis.com/maps/api/js?key=<%=ENV.fetch('GOOGLE_MAPS_KEY', '')%>&callback=Greensteps.initMap">
-</script>
+<% unless Rails.env.test? %>
+  <script async defer
+  src="https://maps.googleapis.com/maps/api/js?key=<%=ENV.fetch('GOOGLE_MAPS_KEY', '')%>&callback=Greensteps.initMap">
+  </script>
+<% end %>
 
 <article class="station_map">
   <header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,9 @@
     <title>Greensteps</title>
     <%= csrf_meta_tags %>
     <%= favicon_link_tag 'favicon32.png' %>
-    <link href="https://fonts.googleapis.com/css?family=Muli" rel="stylesheet">
+    <% unless Rails.env.test? %>
+      <link href="https://fonts.googleapis.com/css?family=Muli" rel="stylesheet">
+    <% end %>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/spec/support/configurations/capybara.rb
+++ b/spec/support/configurations/capybara.rb
@@ -1,21 +1,23 @@
 require 'capybara/rspec'
-require 'capybara/poltergeist'
+require 'selenium/webdriver'
 require 'capybara-screenshot/rspec'
 
-Capybara.register_driver :poltergeist_debug do |app|
-  Capybara::Poltergeist::Driver.new(app, debug: true)
+Capybara.asset_host = 'http://localhost:3000/public'
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
 
-Capybara.asset_host = 'http://localhost:3000/public'
-Capybara.javascript_driver = :poltergeist
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu) }
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+end
+Capybara.javascript_driver = :headless_chrome
+
 Capybara::Screenshot.autosave_on_failure = true
 Capybara::Screenshot.prune_strategy = :keep_last_run
-
-RSpec.configure do |config|
-  config.before(:each, :js) do
-    page.driver.browser.url_blacklist = [
-      'https://maps.googleapis.com',
-      'https://fonts.googleapis.com'
-    ]
-  end
-end


### PR DESCRIPTION
phantomjs is no longer maintained and it looks like using it might be 
causing CI issues

bummer that we can't block urls w/ headless chrome